### PR TITLE
上一个界面为全屏时会出错。

### DIFF
--- a/keyboardchangelib/src/main/java/com/yescpu/keyboardchangelib/KeyboardChangeListener.java
+++ b/keyboardchangelib/src/main/java/com/yescpu/keyboardchangelib/KeyboardChangeListener.java
@@ -16,6 +16,8 @@ public class KeyboardChangeListener implements ViewTreeObserver.OnGlobalLayoutLi
     private int mOriginHeight;
     private int mPreHeight;
     private KeyBoardListener mKeyBoardListen;
+	/*状态栏高度*/
+    private float statusbarHeight = 0;
 
     public interface KeyBoardListener {
         /**
@@ -42,6 +44,15 @@ public class KeyboardChangeListener implements ViewTreeObserver.OnGlobalLayoutLi
     }
 
     private View findContentView(Activity contextObj) {
+		try {
+            int resourceId = contextObj.getResources().getIdentifier("status_bar_height", "dimen", "android");
+            if (resourceId > 0) {
+                //获取状态栏高度
+                statusbarHeight = contextObj.getResources().getDimensionPixelSize(resourceId);
+            }
+        }catch (Exception e){
+
+        }
         return contextObj.findViewById(android.R.id.content);
     }
 
@@ -57,6 +68,10 @@ public class KeyboardChangeListener implements ViewTreeObserver.OnGlobalLayoutLi
             return;
         }
         boolean hasChange = false;
+		if(Math.abs(mOriginHeight-currHeight)<=Math.floor(statusbarHeight)){
+            /*修正，上一个界面为全屏时计算错误问题*/
+            mOriginHeight = currHeight;
+        }
         if (mPreHeight == 0) {
             mPreHeight = currHeight;
             mOriginHeight = currHeight;


### PR DESCRIPTION
//修复“当上一个界面为全屏时，由于状态栏高度导致的计算错误”的bug.
//同时，软键盘属性可以设置为：android:windowSoftInputMode="adjustResize|stateHidden"，因为有的界面收起可能会有问题。