### PR TITLE
修复刘海屏全面屏获取高度不正确导致软键盘高度获取不正确bug

### DIFF
--- a/keyboardchangelib/src/main/java/com/yescpu/keyboardchangelib/KeyboardChangeListener.java
+++ b/keyboardchangelib/src/main/java/com/yescpu/keyboardchangelib/KeyboardChangeListener.java
@@ -110,7 +110,11 @@ public class KeyboardChangeListener implements ViewTreeObserver.OnGlobalLayoutLi
         Display defaultDisplay = mWindow.getWindowManager().getDefaultDisplay();
         int screenHeight = 0;
         Point point = new Point();
-        defaultDisplay.getSize(point);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            defaultDisplay.getRealSize(point);
+        } else {
+            defaultDisplay.getSize(point);
+        }
         screenHeight = point.y;
         return screenHeight;
     }


### PR DESCRIPTION
在手机是刘海屏或者全面屏的时候，defaultDisplay.getSize(point)获取到的高度不正确 ，在软键盘关闭时，回调的高度是负数，在软键盘开启时，高度不正确